### PR TITLE
terraform-ci supports python 3.6 and 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 /.env.tar
 /dist/
 /.eggs/
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ sudo: required
 python:
 - '3.6'
 - '3.7'
-matrix:
-    include:
-    - python: '3.6'
-    - python: '3.7'
 install:
 - make bootstrap
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ dist: xenial
 language: python
 sudo: required
 python:
+- '3.6'
 - '3.7'
+matrix:
+    include:
+    - python: '3.6'
+    - python: '3.7'
 install:
 - make bootstrap
 script:
@@ -13,5 +18,6 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     branch: master
+    python: '3.7'
   password:
     secure: EQfYMuzXC2qDjc1G4KD3bq8S/ieFujBRUaaxAcigeQ/t/4tkFRIXK+ElE3RAGTgtM8pdb8L/mWB3r8bRMDkA3JCTJIbxxOOzaZntm+JUMhVH+h2Ud667LGNFLA/HITnMXk9j2+vB0+IRSAV1SJdFCReJo/wecM+lqDjv2NWDfaycJ+iqyKt+Fg0F36TMgwvQJsuQ0XMivNaf0Cx4AWvfh7r/5GeJG+Lpb+nA9ogkjRUhBcyDkVRd2EjO2fkbK/CUR5JBOwc6rMmB/GYe6j2j8aXbDqxxO34W0hH/3oQSjpXv3zHXwBNkJLG/l1VYd6uxto620x13pICUnZ/v0F8v6/UazSKFXqptGAnrOtRmaJuOmGrp1VTDKeXMI81llfS9YbYysYOmgJ2J6szhtoGD+6d8/DY/YyJsV9t4OQSSM60UN/dC5BW0v1HOIpqLnqBoIxLqQiCM7A+E1zWjvZY3/Uo3WZGvz0gDkIyb+wmZ2tBftaVANwKQJPBSNSvcyBlwAL3Xvaw1QrWihva5jLI8Sjz+QVYD1qgVkW704z1qH3pj24RJQ4dO2t9KLF0s8ZdPSGOY5u4R67Hbkb5swxU1QS02OVhRTwgDYrVPQxQ8UppIm4JR/o+t5UaAAmcv9w20geHM1ByRdfbgrM5kl9lE+aT05yi/MpINnU2kRplxdao=

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ install: ## install the package
 	python setup.py install
 
 .PHONY: test
-test: ## run tests
+test: ## run unit tests
 	python setup.py test
+
+.PHONY: test-all
+test-all: ## run unit tests on all supported python versions
+	tox
 
 clean: clean-build clean-pyc clean-test clean-docs ## remove all build, test, coverage and Python artifacts
 

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -2,3 +2,4 @@ mock ~= 3.0
 pylint ~= 2.3
 pytest ~= 4.5
 pytest-cov ~= 2.7
+tox ~= 3.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.3
+current_version = 0.3.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,11 @@ if __name__ == '__main__':
             'Natural Language :: English',
             'Operating System :: POSIX :: Linux',
             'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.6'
             'Programming Language :: Python :: 3.7'
         ],
         setup_requires=SETUP_REQUIREMENTS,
         test_suite='tests',
         tests_require=TEST_REQUIREMENTS,
+        python_require='>=3.6'
     )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ SETUP_REQUIREMENTS = parse_requirements('requirements/requirements_setup.txt')
 if __name__ == '__main__':
     setup(
         name='terraform-ci',
-        version='0.2.3',
+        version='0.3.0',
         description="Terraform CI runs terraform in Travis-CI",
         long_description=dedent(
             """

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -5,7 +5,7 @@ import sys
 from os import environ, path as osp
 from subprocess import Popen, PIPE
 
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 DEFAULT_TERRAFORM_VARS = '.env/tf_env.json'
 LOG = logging.getLogger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py36,py37
+
+[testenv]
+whitelist_externals=make
+commands=make lint test


### PR DESCRIPTION
Run tests for both versions in travis.
For local development also have a tox config.
One can run locally tests on all supported versions with `make test-all`