### PR TITLE
Strip backend

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 boto3 ~= 1.10
 Click ~= 7.0
+pyhcl ~= 0.3
 requests ~= 2.22

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ SETUP_REQUIREMENTS = parse_requirements("requirements/requirements_setup.txt")
 if __name__ == "__main__":
     setup(
         name="terraform-ci",
-        version="0.9.0",
+        version="0.10.0",
         description="Terraform CI runs terraform in Travis-CI",
         long_description=dedent(
             """

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import boto3
 import hcl
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 DEFAULT_TERRAFORM_VARS = ".env/tf_env.json"
 LOG = logging.getLogger(__name__)

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -3,12 +3,15 @@ import json
 import logging
 import sys
 from contextlib import contextmanager
+from glob import glob
 from os import environ, path as osp
+from shutil import copy2, rmtree
 from subprocess import Popen, PIPE, CalledProcessError
+from tempfile import mkdtemp
 from urllib.parse import urlparse
 
 import boto3
-
+import hcl
 
 __version__ = "0.9.0"
 
@@ -460,3 +463,47 @@ def terraform_apply(
                 stderr=None,
                 cwd=path,
             )
+
+
+@contextmanager
+def strip_backend(path):
+    """
+    Copy terraform file (found by a suffix ``*.tf``) to a temporary directory.
+    While copying look for backend configuration and skip it.
+    This is needed to prepare module code for a unit test. In the production module
+    you may want to configure state to save in an S3 bucket, but for a test it's not needed,
+    the state is temporary.
+
+    The function returns path to the temporary directory.
+
+    After the function exits the ``with`` scope the temporary directory will be removed.
+
+    :param path: path to terraform module.
+    :type path: str
+    :return: Path to temporary directory with the original terraform files except
+        one with the backend configuration.
+    :rtype: str
+    """
+    tmpdir = mkdtemp()
+
+    def copy_file(src, dst):
+        LOG.debug("%s => %s", src, dst)
+        copy2(src, dst)
+
+    try:
+        for tf_file in glob(osp.join(path, "*.tf")):
+            try:
+                if "terraform" in hcl.load(open(tf_file)):
+                    LOG.debug("Found backend config in %s. Skipping it.", tf_file)
+                    continue
+
+                copy_file(tf_file, osp.join(tmpdir, osp.basename(tf_file)))
+
+            except ValueError:
+                LOG.warning("Failed to parse %s, will copy it anyway.", tf_file)
+                copy_file(tf_file, osp.join(tmpdir, osp.basename(tf_file)))
+
+        yield tmpdir
+
+    finally:
+        rmtree(tmpdir)

--- a/tests/terraform_ci/test_strip_backend.py
+++ b/tests/terraform_ci/test_strip_backend.py
@@ -1,0 +1,15 @@
+"""Tests for strip_backend() function."""
+from os import path as osp
+from terraform_ci import strip_backend
+
+
+def test_strip_backend(tmpdir):
+    """Check that main.tf is copied."""
+    original_tf_dir = tmpdir.mkdir("original")
+    tf_file = original_tf_dir.join("main.tf")
+    tf_file.write("")
+
+    with strip_backend(str(original_tf_dir)) as tmp_tf_dir:
+        assert osp.exists(
+            osp.join(tmp_tf_dir, "main.tf")
+        )


### PR DESCRIPTION
strip_backend() copies terraform files to a temporary directory but skips one with the backend configuration.

