### PR TITLE
Fix "AttributeError: 'NoneType' object has no attribute 'keys'"

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
 boto3 ~= 1.10
+botocore >= 1.13.46
 Click ~= 7.0
 PyGithub ~= 1.45
 pyhcl ~= 0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.11.1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ SETUP_REQUIREMENTS = parse_requirements("requirements/requirements_setup.txt")
 if __name__ == "__main__":
     setup(
         name="terraform-ci",
-        version="0.11.0",
+        version="0.11.1",
         description="Terraform CI runs terraform in Travis-CI",
         long_description=dedent(
             """

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -19,7 +19,7 @@ import boto3
 import hcl
 from github import Github
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 DEFAULT_TERRAFORM_VARS = ".env/tf_env.json"
 DEFAULT_PROGRESS_INTERVAL = 10

--- a/tests/terraform_ci/test_delete_outdated_comments.py
+++ b/tests/terraform_ci/test_delete_outdated_comments.py
@@ -1,0 +1,83 @@
+"""Tests for delete_outdated_comments()."""
+import os
+
+import mock
+import pytest
+
+from terraform_ci import delete_outdated_comments
+
+
+@pytest.mark.parametrize(
+    "token, kwargs", [(None, {}), ("foo_token", {"login_or_token": "foo_token"})]
+)
+@mock.patch("terraform_ci.Github")
+def test_delete_outdated_comments_token_from_args(mock_github, token, kwargs):
+    """Check if GitHub() is instantiated with correct github token."""
+
+    delete_outdated_comments({}, "foo_repo", 1, github_token=token)
+    mock_github.assert_called_once_with(**kwargs)
+
+
+@mock.patch("terraform_ci.Github")
+def test_delete_outdated_comments_token_from_env(mock_github):
+    """Check if GitHub() takes the token from environment"""
+    assert "GITHUB_TOKEN" not in os.environ
+    try:
+        os.environ["GITHUB_TOKEN"] = "foo_token"
+        delete_outdated_comments({}, "foo_repo", 1)
+        mock_github.assert_called_once_with(login_or_token="foo_token")
+
+    finally:
+        del os.environ["GITHUB_TOKEN"]
+
+
+@pytest.mark.parametrize(
+    "status, status_in_comment, expected_delete_calls",
+    [
+        ({}, None, 0),
+        ({}, {}, 1),
+        ({"foo": "bar"}, {"foo": "bar"}, 1),
+        ({"foo": "bar", "bar": "foo"}, {"bar": "foo", "foo": "bar"}, 1),
+        ({"foo": "bar"}, {"bar": "foo"}, 0),
+    ],
+)
+@mock.patch("terraform_ci.Github")
+@mock.patch("terraform_ci.get_status_from_comment")
+def test_delete_outdated_comments(
+        mock_get_status_from_comment,
+        mock_github,
+        status,
+        status_in_comment,
+        expected_delete_calls,
+):
+    """Check if delete() is called."""
+    assert "GITHUB_TOKEN" not in os.environ
+
+    mock_client = mock.Mock()
+    mock_github.return_value = mock_client
+
+    mock_repo = mock.Mock()
+    mock_client.get_repo.return_value = mock_repo
+
+    mock_pull = mock.Mock()
+    mock_repo.get_pull.return_value = mock_pull
+
+    author = "foo_user"
+    mock_comment = mock.Mock()
+    mock_comment.user.login = author
+    mock_pull.get_issue_comments.return_value = [mock_comment]
+
+    mock_get_status_from_comment.return_value = status_in_comment
+
+    mock_user = mock.Mock()
+    mock_user.login = author
+    mock_client.get_user.return_value = mock_user
+
+    delete_outdated_comments(status, "foo_repo", 123)
+
+    mock_github.assert_called_once_with()
+    mock_client.get_repo.assert_called_once_with("foo_repo")
+    mock_client.get_user.assert_called_once_with()
+    mock_repo.get_pull.assert_called_once_with(123)
+    mock_pull.get_issue_comments.assert_called_once_with()
+    assert mock_comment.delete.call_count == expected_delete_calls


### PR DESCRIPTION
It fixes crashes like

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.7.1/bin/terraform-ci", line 10, in <module>
    sys.exit(terraform_ci())
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/terraform_ci/ci_runner.py", line 84, in terraform_ci
    status, environ["TRAVIS_REPO_SLUG"], int(environ["TRAVIS_PULL_REQUEST"])
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/terraform_ci/__init__.py", line 78, in delete_outdated_comments
    sorted(status_in_comment.keys()) == sorted(status.keys()),
AttributeError: 'NoneType' object has no attribute 'keys'
```