### PR TITLE
Capture stdout/err only for plan

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.2
+current_version = 0.13.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ SETUP_REQUIREMENTS = parse_requirements("requirements/requirements_setup.txt")
 if __name__ == "__main__":
     setup(
         name="terraform-ci",
-        version="0.12.2",
+        version="0.13.0",
         description="Terraform CI runs terraform in Travis-CI",
         long_description=dedent(
             """

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -19,7 +19,7 @@ import boto3
 import hcl
 from github import Github
 
-__version__ = "0.12.2"
+__version__ = "0.13.0"
 
 DEFAULT_TERRAFORM_VARS = ".env/tf_env.json"
 DEFAULT_PROGRESS_INTERVAL = 10

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -365,7 +365,12 @@ def run_job(path, action):
         }
     :rtype: dict
     """
-    returncode, cout, cerr = execute(["make", "-C", path, action])
+    stdout = PIPE if action == "plan" else None
+    stderr = PIPE if action == "plan" else None
+
+    returncode, cout, cerr = execute(
+        ["make", "-C", path, action], stdout=stdout, stderr=stderr
+    )
     status = {"success": returncode == 0, "stderr": cerr, "stdout": cout}
     parse_tree = parse_plan(cout.decode("utf-8"))
     status["add"] = parse_tree[0]


### PR DESCRIPTION
When running `terraform-ci apply` one wants to see output realtime for better troubleshooting.