### PR TITLE
--aws-assume-role-arn works only for setting environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.2
+current_version = 0.14.0
 commit = True
 tag = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 1.0.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ SETUP_REQUIREMENTS = parse_requirements("requirements/requirements_setup.txt")
 if __name__ == "__main__":
     setup(
         name="terraform-ci",
-        version="0.13.2",
+        version="0.14.0",
         description="Terraform CI runs terraform in Travis-CI",
         long_description=dedent(
             """

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ SETUP_REQUIREMENTS = parse_requirements("requirements/requirements_setup.txt")
 if __name__ == "__main__":
     setup(
         name="terraform-ci",
-        version="0.14.0",
+        version="1.0.0",
         description="Terraform CI runs terraform in Travis-CI",
         long_description=dedent(
             """

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -19,7 +19,7 @@ import boto3
 import hcl
 from github import Github
 
-__version__ = "0.13.2"
+__version__ = "0.14.0"
 
 DEFAULT_TERRAFORM_VARS = ".env/tf_env.json"
 DEFAULT_PROGRESS_INTERVAL = 10

--- a/terraform_ci/__init__.py
+++ b/terraform_ci/__init__.py
@@ -19,7 +19,7 @@ import boto3
 import hcl
 from github import Github
 
-__version__ = "0.14.0"
+__version__ = "1.0.0"
 
 DEFAULT_TERRAFORM_VARS = ".env/tf_env.json"
 DEFAULT_PROGRESS_INTERVAL = 10
@@ -446,7 +446,7 @@ def read_from_secretsmanager(url, role=None):
         session = boto3.Session(
             aws_access_key_id=response["Credentials"]["AccessKeyId"],
             aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
-            aws_session_token=response["Credentials"]["SessionToken"]
+            aws_session_token=response["Credentials"]["SessionToken"],
         )
     else:
         session = boto3.Session()

--- a/terraform_ci/ci_runner.py
+++ b/terraform_ci/ci_runner.py
@@ -42,7 +42,7 @@ from terraform_ci.post_plan import post_comment
 )
 @click.option(
     "--aws-assume-role-arn",
-    help="ARN of any role the environment should assume before running terraform.",
+    help="ARN of any role the environment should assume to setup environment.",
     default="",
     show_default=False,
     required=False,
@@ -75,11 +75,8 @@ def terraform_ci(**kwargs):
     except KeyError:
         pull_request = False
 
-    if aws_assume_role_arn:
-        assume_aws_role(aws_assume_role_arn)
-
     try:
-        setup_environment(env_file)
+        setup_environment(env_file, role=aws_assume_role_arn)
 
     except FileNotFoundError:
         LOG.warning("Environment file %s doesn't exit", env_file)

--- a/terraform_ci/ci_runner.py
+++ b/terraform_ci/ci_runner.py
@@ -7,7 +7,6 @@ from terraform_ci import (
     DEFAULT_TERRAFORM_VARS,
     setup_environment,
     run_job,
-    assume_aws_role,
     render_comment,
     module_name_from_path,
     convert_to_newlines,

--- a/tests/terraform_ci/test_setup_environment.py
+++ b/tests/terraform_ci/test_setup_environment.py
@@ -120,7 +120,8 @@ def test_setup_environment_from_secretsmanager(
     mock_read_from_secretsmanager.return_value = 'foo_value'
     setup_environment(config_path=str(conf))
     mock_read_from_secretsmanager.assert_called_once_with(
-        'secretsmanager:///path/to/secret:key'
+        'secretsmanager:///path/to/secret:key',
+        role=None
     )
     assert environ["TF_VAR_fookey"] == "foo_value"
 
@@ -149,6 +150,7 @@ def test_setup_environment_from_secretsmanager_github(
     mock_read_from_secretsmanager.return_value = 'foo_value'
     setup_environment(config_path=str(conf))
     mock_read_from_secretsmanager.assert_called_once_with(
-        'secretsmanager:///path/to/secret:key'
+        'secretsmanager:///path/to/secret:key',
+        role=None
     )
     assert environ["GITHUB_TOKEN"] == "foo_value"


### PR DESCRIPTION
If --aws-assume-role-arn is specified it will be assumed only to setup environment variables listed in `.env/tf_vars.json`.
It will not set `AWS_*` variables and it is different behaviour from versions `0.*`.
